### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "lodash": "^3.10.1",
     "minimist": "^1.1.2",
     "mkdirp": "^0.5.1",
-    "node-uuid": "^1.4.3",
     "pleasant-progress": "^1.1.0",
     "require-all": "^2.0.0",
     "resolve": "^1.1.6",
     "rimraf": "^2.4.2",
     "swag": "^0.7.0",
     "through": "^2.3.8",
+    "uuid": "^3.0.0",
     "validate-npm-package-name": "^2.2.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import Project from './models/project';
 import Command from './models/command';
 import Generator from './models/generator';
 import * as utils from 'lodash';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 
 export {default as Command} from './models/command';
 export {default as Generator} from './models/generator';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.